### PR TITLE
Add missing period for abbreviation to prevent false positives

### DIFF
--- a/PragmaticSegmenterNet/Cleaner.cs
+++ b/PragmaticSegmenterNet/Cleaner.cs
@@ -150,7 +150,7 @@
             {
                 var abbr = language.CleanedAbbreviations[i];
                 
-                if (word.IndexOf(abbr, StringComparison.OrdinalIgnoreCase) >= 0)
+                if (word.IndexOf(abbr + ".", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     return txt;
                 }


### PR DESCRIPTION
`CleanedAbbreviations` refers to the data from `Language.Abbreviations`, whose content does not end with a period. As a consequence, during substring matching we get many false positives, e.g. in `German Language.cs` the abbreviation "gen" matches the word "genau". Therefore, we have to add a period before checking for a match.

P.S. Many thanks for porting that great library.